### PR TITLE
Avoid potential race condition

### DIFF
--- a/plot/plot.go
+++ b/plot/plot.go
@@ -491,14 +491,12 @@ func (p *Plot) RetryDownload(ctx context.Context) (err error) {
 
 func (p *Plot) Download(ctx context.Context) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
-	defer func() {
-		cancel()
-		p.cancelDownload = nil
-	}()
-
 	p.cancelDownload = cancel
 
 	defer func() {
+		p.cancelDownload()
+		p.cancelDownload = nil
+
 		if err != nil {
 			log.Errorf("%s download failed: %s", p, err.Error())
 			p.updateDownloadState(DownloadStateFailed)


### PR DESCRIPTION
The rationale behind this is the following: the `defer`s in this function are called in a LIFO order. What this means is that we might set the download status to `DownloadStatusFailed` before the `cancelDownload` is wiped.

This *can be a problem* if the 'processor' enters [here](https://github.com/chiafactory/plotorder/blob/main/processor/processor.go#L233) and the second `defer` (where we remove `cancelDownload`) runs between [these lines](https://github.com/chiafactory/plotorder/blob/6688b5b1e77a7729ad028f6299acc2253a34def8/plot/plot.go#L482-L484)

This race condition can be avoided by cleaning up `cancelDownload` before setting the status to `DownloadStatusFailed`, which is what we're doing in this PR.
